### PR TITLE
Dockerfile: switch to ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10 AS base
+FROM ubuntu:22.04 AS base
 
 # install required packages
 ENV DEBIAN_FRONTEND=noninteractive 


### PR DESCRIPTION
This is an LTS version.
The build with 22.10 failed.